### PR TITLE
fix: update installer to generate new hooks format (v3.3.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,49 @@ All notable changes to Claude Code Audio Hooks will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.2] - 2025-11-07
+
+### 🐛 Critical Bug Fix: Hooks Format Compatibility
+
+Fixed critical issue where installer generated deprecated hooks format, causing Claude Code to report invalid settings.
+
+### Fixed
+- **Installer generates deprecated hooks format**:
+  - `install-complete.sh` was creating hooks as strings (old format)
+  - Claude Code v2.0.32+ requires array format with matchers
+  - Updated Python script to generate new format: `[{"hooks": [{"type": "command", "command": "path"}]}]`
+  - Affected all 9 hook types during installation
+
+### Impact
+- ✅ **Fixes `/doctor` reporting "Invalid Settings"** errors
+- ✅ **Ensures hooks work immediately** after installation
+- ✅ **Compatible with Claude Code v2.0.32+** (current version)
+- ✅ **No breaking changes** - upgrade path is seamless
+
+### Technical Details
+```python
+# Before (old format - fails validation)
+settings['hooks']['Notification'] = '~/.claude/hooks/notification_hook.sh'
+
+# After (new format - passes validation)
+settings['hooks']['Notification'] = [
+    {
+        'hooks': [
+            {
+                'type': 'command',
+                'command': '~/.claude/hooks/notification_hook.sh'
+            }
+        ]
+    }
+]
+```
+
+### Migration
+Users who installed with older versions can:
+1. Re-run `bash scripts/install-complete.sh` to regenerate settings
+2. Or manually update `~/.claude/settings.json` to use new format
+3. See [hooks documentation](https://code.claude.com/docs/en/hooks) for details
+
 ## [3.3.1] - 2025-11-06
 
 ### 🐛 Critical Bug Fixes: Installation Script Stability

--- a/scripts/install-complete.sh
+++ b/scripts/install-complete.sh
@@ -379,7 +379,8 @@ try:
     else:
         settings = {}
 
-    # Add hooks
+    # Add hooks using the new format (Claude Code v2.0.32+)
+    # New format: Each hook is an array of matcher objects containing hooks arrays
     if 'hooks' not in settings:
         settings['hooks'] = {}
 
@@ -396,13 +397,23 @@ try:
     }
 
     for hook_name, hook_path in hooks.items():
-        settings['hooks'][hook_name] = hook_path
+        # Convert to new array format with matcher structure
+        settings['hooks'][hook_name] = [
+            {
+                'hooks': [
+                    {
+                        'type': 'command',
+                        'command': hook_path
+                    }
+                ]
+            }
+        ]
 
     # Save settings
     with open(settings_file, 'w') as f:
         json.dump(settings, f, indent=2)
 
-    print(f"Configured {len(hooks)} hooks in settings.json")
+    print(f"Configured {len(hooks)} hooks in settings.json (new format)")
     sys.exit(0)
 
 except Exception as e:


### PR DESCRIPTION
# Fix: Update Installer to Generate New Hooks Format (v3.3.2)

## Summary

Fixed critical bug where `install-complete.sh` was generating hooks in the deprecated string format, causing Claude Code v2.0.32+ to report "Invalid Settings" errors.

## Changes

### 1. Updated `scripts/install-complete.sh`
- Modified Python script to generate new array-based hooks format
- Each hook now formatted as: `[{"hooks": [{"type": "command", "command": "path"}]}]`
- Added comments explaining the new format requirement
- Updated success message to indicate new format generation

### 2. Updated `CHANGELOG.md`
- Added v3.3.2 release notes
- Documented the bug fix with technical details
- Included migration instructions for existing users

## Technical Details

**Before (Old Format - Fails Validation):**
```python
for hook_name, hook_path in hooks.items():
    settings['hooks'][hook_name] = hook_path
```

Generated JSON:
```json
{
  "hooks": {
    "Notification": "~/.claude/hooks/notification_hook.sh"
  }
}
```

**After (New Format - Passes Validation):**
```python
for hook_name, hook_path in hooks.items():
    settings['hooks'][hook_name] = [
        {
            'hooks': [
                {
                    'type': 'command',
                    'command': hook_path
                }
            ]
        }
    ]
```

Generated JSON:
```json
{
  "hooks": {
    "Notification": [
      {
        "hooks": [
          {
            "type": "command",
            "command": "~/.claude/hooks/notification_hook.sh"
          }
        ]
      }
    ]
  }
}
```

## Testing

✅ Tested Python script generates correct JSON format
✅ Verified format matches Claude Code v2.0.32+ requirements
✅ Confirmed `/doctor` validation passes with new format
✅ Hooks function correctly after installation

## Impact

- ✅ **Fixes `/doctor` reporting "Invalid Settings"** for all 9 hooks
- ✅ **Ensures hooks work immediately** after installation
- ✅ **Compatible with Claude Code v2.0.32+** (current version: 2.0.35)
- ✅ **No breaking changes** - seamless upgrade path
- ✅ **Backward compatible** - doesn't affect existing installations

## Migration for Existing Users

Users who installed with v3.3.1 or earlier can:
1. Re-run `bash scripts/install-complete.sh` to regenerate settings with correct format
2. Or manually update `~/.claude/settings.json` to use new format
3. See [hooks documentation](https://code.claude.com/docs/en/hooks) for details

## Checklist

- [x] Code changes tested locally
- [x] CHANGELOG.md updated with v3.3.2 release notes
- [x] Commit message follows project conventions
- [x] No breaking changes
- [x] Documentation references included
- [x] Migration path documented for existing users

## Related Issue

Fixes #1

## Documentation References

- [Claude Code Hooks Documentation](https://code.claude.com/docs/en/hooks)
- Hooks format change in Claude Code v2.0.32+
