### PR TITLE
fix(hook_runner): import Tuple to unblock every audio-hooks command (fixes #10)

### DIFF
--- a/hooks/hook_runner.py
+++ b/hooks/hook_runner.py
@@ -27,7 +27,7 @@ import subprocess
 import platform
 import re
 from pathlib import Path
-from typing import Optional, Dict, Any, List
+from typing import Optional, Dict, Any, List, Tuple
 
 # Version used for auto-sync: when the installed copy in ~/.claude/hooks/
 # detects a newer version in the project directory, it self-updates.

--- a/plugins/audio-hooks/hooks/hook_runner.py
+++ b/plugins/audio-hooks/hooks/hook_runner.py
@@ -27,7 +27,7 @@ import subprocess
 import platform
 import re
 from pathlib import Path
-from typing import Optional, Dict, Any, List
+from typing import Optional, Dict, Any, List, Tuple
 
 # Version used for auto-sync: when the installed copy in ~/.claude/hooks/
 # detects a newer version in the project directory, it self-updates.


### PR DESCRIPTION
## Summary

- `hooks/hook_runner.py` uses `Tuple` in module-level type annotations (line 765 `SYNTHETIC_EVENT_MAP` and line 802 `_resolve_synthetic_event`) but never imported it. Because the file has no `from __future__ import annotations`, CPython evaluates these annotations at import time and raises `NameError: name 'Tuple' is not defined`, so **every** `audio-hooks` subcommand (`diagnose`, `status`, `version`, `test`, …) crashes before dispatch.
- One-line fix: add `Tuple` to the `typing` import on line 30.
- `plugins/audio-hooks/hooks/hook_runner.py` was synced via `bash scripts/build-plugin.sh` (canonical → plugin layout, per `CLAUDE.md`).

Fixes #10

## Why not `from __future__ import annotations`?

The reporter suggested that as an alternative. I kept the explicit import because:
1. Minimal surface area — zero behaviour change elsewhere.
2. Other modules in the codebase may rely on `typing.get_type_hints` / runtime introspection of annotations; string-ifying every annotation has subtle side-effects.
3. The reporter confirmed the explicit import fixes the crash.

## Scope

Intentionally **not** in this PR:
- Version bump / CHANGELOG entry (left to maintainer — local repo is at `5.0.3` but a `v5.1.0` tag already exists on origin, so release cadence is not mine to decide).
- CI import-smoke test (no `tests/` directory exists today; worth a follow-up PR).
- Audit of the rest of the codebase for similar missing-import bugs.

## Test plan

Verified locally on Windows 11 / Python 3.14:

- [x] `bash scripts/build-plugin.sh --check` → `{"ok":true,"in_sync":true,"checked":60}`
- [x] `python -c "import sys; sys.path.insert(0, 'hooks'); import hook_runner"` → no traceback
- [x] `python -c "import sys; sys.path.insert(0, 'plugins/audio-hooks/hooks'); import hook_runner"` → no traceback
- [x] `python bin/audio-hooks.py version` → `{"ok":true,"version":"5.0.3",...}`
- [x] `python bin/audio-hooks.py status` → `{"ok":true,...}`
- [x] `python bin/audio-hooks.py diagnose` → `{"ok":true,...,"errors":[],"warnings":[]}`
- [x] `python bin/audio-hooks.py test all` → `{"ok":true,"passed":26,"failed":[],"total":26}`

These are exactly the commands the reporter showed failing in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)